### PR TITLE
fix double receiving

### DIFF
--- a/ServiceApp/server/src/services/zmqService.ts
+++ b/ServiceApp/server/src/services/zmqService.ts
@@ -200,9 +200,7 @@ export class ZmqService {
             if (tag.startsWith(this._config.prefix) && messageType && operationList.includes(tag.slice(9, 15))) {
                 const bundle = messageParams[8];
 
-                if (this.sentBundles.includes(bundle)) {
-                    this.sentBundles = [];
-                } else {
+                if (!this.sentBundles.includes(bundle)) {
                     this.sentBundles.push(bundle);
 
                     interface IUser {


### PR DESCRIPTION
Through the MAM's there are even more transactions under the same bundle hash.
So if every second time with the same bundle hash, we empty the array, every other transaction is send to the client again. 

Since we have the interval cleaning of the array, I think this is sufficient. 